### PR TITLE
Use snake_case instead of camelCase for a function

### DIFF
--- a/docs/dispensables.md
+++ b/docs/dispensables.md
@@ -21,7 +21,7 @@ if (employee.flags and HOURLY_FLAG) and (employee.age > 65):
 **Good:**
 
 ```python
-if employee.isEligibleForBenefits():
+if employee.is_eligible_for_benefits():
     # do something
 ```
 


### PR DESCRIPTION
It seems mistakenly camelCase is used for a function. Let's change it to snake_case.