### PR TITLE
Correct type hint @ split_into_first_and_last_name

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -235,7 +235,7 @@ split_into_first_and_last_name()
 **Good:**
 
 ```python
-def split_into_first_and_last_name(name: str) -> None:
+def split_into_first_and_last_name(name: str) -> list:
     return name.split()
 
 name = 'Ryan McDermott'


### PR DESCRIPTION
The return type hint for the refactored function split_into_first_and_last_name mistakenly is set to None, which instead should be either "list" or "List[str]."